### PR TITLE
Add OS X build process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,12 @@ set(SOURCES
   main.cpp
 )
 
-add_executable(spiel ${SOURCES})
+add_executable(spiel MACOSX_BUNDLE ${SOURCES})
 set_target_properties(spiel PROPERTIES
   COMPILE_FLAGS "-D_DEBUG_MODE=1"
   LINK_FLAGS "-framework cocoa -framework opengl -framework IOKit"
 )
 target_link_libraries(spiel lua Irrlicht irrklang)
+if (APPLE)
+  set_target_properties(spiel PROPERTIES OUTPUT_NAME "Spiel")
+endif (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES
   Ground.cpp
   Hero.cpp
   HeroPunk.cpp
+  LoadingScreen.cpp
   Logfile.cpp
   MapTile.cpp
   Mauspfeil.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,66 @@
+cmake_minimum_required (VERSION 3.0)
+project (Spiel)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
+
+set(IRRLICHT_DIR ${CMAKE_SOURCE_DIR}/Debug/dependencies/irrlicht-1.8.1)
+include_directories(${IRRLICHT_DIR}/include/)
+include_directories(${IRRLICHT_DIR}/source/Irrlicht/)
+link_directories(${IRRLICHT_DIR}/source/Irrlicht/MacOSX/BD/)
+
+set(IRRKLANG_DIR ${CMAKE_SOURCE_DIR}/Debug/dependencies/irrKlang-1.5.0)
+include_directories(${IRRKLANG_DIR}/include/)
+link_directories(${IRRKLANG_DIR}/bin/macosx-gcc/)
+
+set(SOURCES
+  Basic3DObject.cpp
+  BasicHero.cpp
+  BasicLifeform.cpp
+  BasicStaticObject.cpp
+  BufferCullMeshSceneNode.cpp
+  Camera.cpp
+  Collision.cpp
+  Configuration.cpp
+  DebugShape.cpp
+  DebugShapesManager.cpp
+  DebugStatistics.cpp
+  Debugwindow.cpp
+  Eventreceiver.cpp
+  GameFloatControl.cpp
+  GameStateManager.cpp
+  GenericHelperMethods.cpp
+  Ground.cpp
+  Hero.cpp
+  HeroPunk.cpp
+  Logfile.cpp
+  MapTile.cpp
+  Mauspfeil.cpp
+  ObjectConfiguration.cpp
+  ObjectManager.cpp
+  ObjectParamsExtractor.cpp
+  SaveGames.cpp
+  Scripting.cpp
+  StateLoadGameContent.cpp
+  StateMainMenu.cpp
+  StatePlayTheGame.cpp
+  StateStartup.cpp
+  StateUnloadGameContent.cpp
+  Timer.cpp
+  TimerManager.cpp
+  Ton.cpp
+  Vegetation.cpp
+  Weather.cpp
+  Zufall.cpp
+  main.cpp
+)
+
+add_executable(spiel ${SOURCES})
+set_target_properties(spiel PROPERTIES
+  COMPILE_FLAGS "-D_DEBUG_MODE=1"
+  LINK_FLAGS "-framework cocoa -framework opengl -framework IOKit"
+)
+target_link_libraries(spiel lua Irrlicht irrklang)

--- a/bootstrap_osx.sh
+++ b/bootstrap_osx.sh
@@ -54,7 +54,17 @@ pushd Debug
   popd
 popd
 
-echo go to build directory: cd Debug/BD
-echo build with: make
-echo run with:
-echo "  DYLD_LIBRARY_PATH=$IRRLICHT_BUILD_DIR:$IRRKLANG_PATH/bin/macosx-gcc/ open Spiel.app"
+
+cat << EOF
+================================================================================
+
+Whats next?
+
+go to build directory:
+  $ cd Debug/BD
+build with:
+  $ make
+run game with:
+  $ DYLD_LIBRARY_PATH=$IRRLICHT_BUILD_DIR:$IRRKLANG_PATH/bin/macosx-gcc/ \
+open Spiel.app"
+EOF

--- a/bootstrap_osx.sh
+++ b/bootstrap_osx.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+
+set -ex
+
+which xcodebuild || { echo Install Xcode via AppStore. ; exit 1; }
+which cmake || { echo Install CMake via Homebrew. ; exit 1; }
+which lua || { echo Install Lua via Homebrew ; exit 1; }
+
+IRRLICHT_DIR_NAME=irrlicht-1.8.1
+IRRLICHT_PACKAGE_NAME="$IRRLICHT_DIR_NAME".zip
+IRRLICHT_DOWNLOAD=http://downloads.sourceforge.net/irrlicht/$IRRLICHT_PACKAGE_NAME
+IRRKLANG_DIR_NAME=irrKlang-1.5.0
+IRRKLANG_PACKAGE_NAME=irrKlang-32bit-1.5.0.zip
+IRRKLANG_DOWNLOAD=http://www.ambiera.at/downloads/$IRRKLANG_PACKAGE_NAME
+
+pushd Debug
+
+  # Download and build dependencies:
+  mkdir -p dependencies
+  pushd dependencies
+
+    test -f "$IRRLICHT_PACKAGE_NAME" || curl -LO "$IRRLICHT_DOWNLOAD"
+    test -f "$IRRKLANG_PACKAGE_NAME" || curl -LO "$IRRKLANG_DOWNLOAD"
+
+    test -d "$IRRLICHT_DIR_NAME" || unzip "$IRRLICHT_PACKAGE_NAME"
+    test -d "$IRRKLANG_DIR_NAME" || unzip "$IRRKLANG_PACKAGE_NAME"
+
+    pushd $IRRLICHT_DIR_NAME/source/Irrlicht/MacOSX
+
+      IRRLICHT_BUILD_DIR=$PWD/BD
+      mkdir -p "$IRRLICHT_BUILD_DIR"
+      xcodebuild -configuration Release \
+      	         CONFIGURATION_BUILD_DIR="$IRRLICHT_BUILD_DIR"
+
+    popd
+
+    IRRKLANG_PATH=$PWD/$IRRKLANG_DIR_NAME
+
+  popd
+
+  # Prepaire to build:
+
+  mkdir -p BD
+  pushd BD
+
+  cmake ../..
+
+  popd
+popd
+
+echo go to build directory: cd Debug/BD
+echo build with: make
+echo run with:
+echo "  DYLD_LIBRARY_PATH=$IRRLICHT_BUILD_DIR:$IRRKLANG_PATH/bin/macosx-gcc/ ./spiel"

--- a/bootstrap_osx.sh
+++ b/bootstrap_osx.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -ex
+set -e
 
 which xcodebuild || { echo Install Xcode via AppStore. ; exit 1; }
 which cmake || { echo Install CMake via Homebrew. ; exit 1; }

--- a/bootstrap_osx.sh
+++ b/bootstrap_osx.sh
@@ -45,10 +45,16 @@ pushd Debug
 
   cmake ../..
 
+  ln -s "$PWD/../CONFIG.CFG"
+  ln -s "$PWD/../GFX"
+  ln -s "$PWD/../SAVEGAMES"
+  ln -s "$PWD/../SCRIPTS"
+  ln -s "$PWD/../SFX"
+
   popd
 popd
 
 echo go to build directory: cd Debug/BD
 echo build with: make
 echo run with:
-echo "  DYLD_LIBRARY_PATH=$IRRLICHT_BUILD_DIR:$IRRKLANG_PATH/bin/macosx-gcc/ ./spiel"
+echo "  DYLD_LIBRARY_PATH=$IRRLICHT_BUILD_DIR:$IRRKLANG_PATH/bin/macosx-gcc/ open Spiel.app"

--- a/bootstrap_osx.sh
+++ b/bootstrap_osx.sh
@@ -45,11 +45,11 @@ pushd Debug
 
   cmake ../..
 
-  ln -s "$PWD/../CONFIG.CFG"
-  ln -s "$PWD/../GFX"
-  ln -s "$PWD/../SAVEGAMES"
-  ln -s "$PWD/../SCRIPTS"
-  ln -s "$PWD/../SFX"
+  ln -fs "$PWD/../CONFIG.CFG"
+  ln -fs "$PWD/../GFX"
+  ln -fs "$PWD/../SAVEGAMES"
+  ln -fs "$PWD/../SCRIPTS"
+  ln -fs "$PWD/../SFX"
 
   popd
 popd


### PR DESCRIPTION
* add CMake configuration
* add ``bootstrap_osx.sh`` script, for preparing the development environment on OS X
  * create links
  * download and build dependencies
  * display build instruction for OS X

Maybe we can expand this build process to every other platform.

How does it work?  Run ``./bootstrap_osx.sh``, then follow the instructions displayed by the script.