### PR TITLE
Add tags to tests

### DIFF
--- a/test/LeviathanDeviceTest.cpp
+++ b/test/LeviathanDeviceTest.cpp
@@ -10,7 +10,7 @@
 
 using namespace fakeit;
 
-TEST_CASE("LeviathanDevice supporter") {
+TEST_CASE("LeviathanDevice supporter", "[integration]") {
     leviathan::LeviathanDevice subject;
 
     SECTION("it provides instances of usefull tools") {
@@ -24,7 +24,7 @@ TEST_CASE("LeviathanDevice supporter") {
     }
 }
 
-TEST_CASE("LeviathanDevice main loop") {
+TEST_CASE("LeviathanDevice main loop", "[integration]") {
     Testhelper testhelper;
     const irr::io::path configFileName = "testconfigfile.ini";
     testhelper.writeFile(configFileName, "[video]\nmax_fps=100\nscreen_x=5\nscreen_y=5\n");
@@ -131,7 +131,7 @@ TEST_CASE("LeviathanDevice main loop") {
     }
 }
 
-TEST_CASE("LeviathanDevice exit status") {
+TEST_CASE("LeviathanDevice exit status", "[integration]") {
     leviathan::LeviathanDevice subject;
     Testhelper testhelper;
     const irr::io::path configFileName = "testconfigfile.ini";

--- a/test/core/ConfigurationTest.cpp
+++ b/test/core/ConfigurationTest.cpp
@@ -8,13 +8,13 @@
 // - integer values can be positive or negative
 // - float values may not have leading zeroes, can be positive or negative, and must have a `.` in them
 
-TEST_CASE("Configuration: it provides a default object") {
+TEST_CASE("Configuration: it provides a default object", "[unit]") {
     leviathan::core::Configuration subject;
     REQUIRE(subject.getGraphicEngineParams().DriverType == irr::video::EDT_NULL);
     REQUIRE(subject.getGraphicEngineParams().LoggingLevel == irr::ELL_WARNING);
 }
 
-TEST_CASE("Configuration: read values") {
+TEST_CASE("Configuration: read values", "[unit]") {
     Testhelper testhelper;
     const irr::io::path configFileName = "testconfigfile.ini";
     leviathan::core::Configuration subject;
@@ -106,7 +106,7 @@ TEST_CASE("Configuration: read values") {
     }
 }
 
-TEST_CASE("Configuration: write values") {
+TEST_CASE("Configuration: write values", "[.]") {
     SECTION("it writes back all sections and values") {}
     SECTION("it writes back comments and blank lines") {}
     SECTION("inline comments and white spaces are removed during write") {}

--- a/test/core/GameStateManagerTest.cpp
+++ b/test/core/GameStateManagerTest.cpp
@@ -5,7 +5,7 @@
 
 using namespace fakeit;
 
-TEST_CASE("GameStateManager: add game states") {
+TEST_CASE("GameStateManager: add game states", "[unit]") {
     leviathan::core::GameStateManager subject;
     Mock<leviathan::core::IGameState> startDouble, playDouble, stopDouble;
     Fake(Method(startDouble, update), Method(startDouble, draw));
@@ -32,7 +32,7 @@ TEST_CASE("GameStateManager: add game states") {
     }
 }
 
-TEST_CASE("GameStateManager: transit between game states") {
+TEST_CASE("GameStateManager: transit between game states", "[unit]") {
     leviathan::core::GameStateManager subject;
     Mock<leviathan::core::IGameState> startDouble, playDouble, pauseDouble, optionsDouble;
     Fake(Method(startDouble, update), Method(startDouble, draw));
@@ -83,7 +83,7 @@ TEST_CASE("GameStateManager: transit between game states") {
     }
 }
 
-TEST_CASE("GameStateManager: update and draw active game states") {
+TEST_CASE("GameStateManager: update and draw active game states", "[unit]") {
     leviathan::core::GameStateManager subject;
     Mock<leviathan::core::IGameState> startDouble, playDouble, pauseDouble;
     Fake(Method(startDouble, update), Method(startDouble, draw));

--- a/test/core/LoggerTest.cpp
+++ b/test/core/LoggerTest.cpp
@@ -4,7 +4,7 @@
 #include "irrlicht.h"
 #include <cstdint>
 
-TEST_CASE("Logger: init") {
+TEST_CASE("Logger: init", "[unit]") {
     Testhelper testhelper;
     const irr::io::path logFileName = "testlogfile.log";
     leviathan::core::Logger sample(
@@ -57,7 +57,7 @@ TEST_CASE("Logger: init") {
     }
 }
 
-TEST_CASE("Logger: logging") {
+TEST_CASE("Logger: logging", "[unit]") {
     Testhelper testhelper;
     const irr::io::path logFileName = "testlogfile.log";
 
@@ -93,7 +93,7 @@ TEST_CASE("Logger: logging") {
             REQUIRE(content.find("line.", static_cast<uint32_t>(firstIndex) + 1) > -1);
         }
     }
-    SECTION("it handles different logLevels") {
+    SECTION("it handles different logLevels", "[unit]") {
         leviathan::core::Logger subject(
             testhelper.getFileSystem(),
             testhelper.getGraphicEngine()->getTimer(),

--- a/test/core/RandomizerTest.cpp
+++ b/test/core/RandomizerTest.cpp
@@ -4,7 +4,7 @@
 
 const uint32_t SEED = static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count());
 
-TEST_CASE("Randomizer: seeding") {
+TEST_CASE("Randomizer: seeding", "[unit]") {
     leviathan::core::Randomizer subject;
 
     SECTION("seed evolves internally") {
@@ -26,14 +26,14 @@ TEST_CASE("Randomizer: seeding") {
     }
 }
 
-TEST_CASE("Randomizer: get random Float") {
+TEST_CASE("Randomizer: get random Float", "[unit]") {
     leviathan::core::Randomizer subject;
     subject.start(SEED);
     REQUIRE(subject.getFloat() >= 0.0f);
     REQUIRE(subject.getFloat() < 1.0f);
 }
 
-TEST_CASE("Randomizer: get random float within range") {
+TEST_CASE("Randomizer: get random float within range", "[unit]") {
     leviathan::core::Randomizer subject;
     subject.start(SEED);
     REQUIRE(subject.getFloat(3.0f, 5.0f) >= 3.0f);
@@ -59,14 +59,14 @@ TEST_CASE("Randomizer: get random float within range") {
     }
 }
 
-TEST_CASE("Randomizer: get random Int") {
+TEST_CASE("Randomizer: get random Int", "[unit]") {
     leviathan::core::Randomizer subject;
     subject.start(SEED);
     // REQUIRE(subject.getInt() >= 0); // comparison of unsigned expression >= 0 is always true
     REQUIRE(subject.getInt() <= UINT32_MAX);
 }
 
-TEST_CASE("Randomizer: get random int within range") {
+TEST_CASE("Randomizer: get random int within range", "[unit]") {
     leviathan::core::Randomizer subject;
     subject.start(SEED);
     REQUIRE(subject.getInt(3, 5) >= 3);

--- a/test/core/TimeControlTest.cpp
+++ b/test/core/TimeControlTest.cpp
@@ -2,7 +2,7 @@
 #include "../../source/Leviathan/core/Timer.h"
 #include "catch.hpp"
 
-TEST_CASE("TimeControl: ticking") {
+TEST_CASE("TimeControl: ticking", "[unit]") {
     leviathan::core::TimeControl subject;
     leviathan::core::Timer timer(2.0f);
     timer.start();
@@ -20,7 +20,7 @@ TEST_CASE("TimeControl: ticking") {
     }
 }
 
-TEST_CASE("TimeControl: functionality") {
+TEST_CASE("TimeControl: functionality", "[unit]") {
     leviathan::core::TimeControl subject;
     leviathan::core::Timer timer1(1.0f);
     leviathan::core::Timer timer2(2.0f);

--- a/test/core/TimerTest.cpp
+++ b/test/core/TimerTest.cpp
@@ -2,7 +2,7 @@
 #include "catch.hpp"
 #include "irrlicht.h"
 
-TEST_CASE("Timer: architecture") {
+TEST_CASE("Timer: architecture", "[unit]") {
     leviathan::core::Timer timer(2.0f);
 
     SECTION("tick() starts chains") {
@@ -11,7 +11,7 @@ TEST_CASE("Timer: architecture") {
     }
 }
 
-TEST_CASE("Timer: max value") {
+TEST_CASE("Timer: max value", "[unit]") {
 
     SECTION("zero is not forbidden") {
         leviathan::core::Timer timer(0.0f);
@@ -39,7 +39,7 @@ TEST_CASE("Timer: max value") {
     }
 }
 
-TEST_CASE("Timer: ticking") {
+TEST_CASE("Timer: ticking", "[unit]") {
     leviathan::core::Timer timer(2.0f);
 
     SECTION("it does not tick") {
@@ -117,7 +117,7 @@ TEST_CASE("Timer: ticking") {
     }
 }
 
-TEST_CASE("Timer: states") {
+TEST_CASE("Timer: states", "[unit]") {
     leviathan::core::Timer timer(2.0f);
 
     SECTION("it is not running") {

--- a/test/input/ActionsTest.cpp
+++ b/test/input/ActionsTest.cpp
@@ -8,7 +8,7 @@
 
 using namespace fakeit;
 
-TEST_CASE("Action Mapping") {
+TEST_CASE("Action Mapping", "[unit]") {
     Testhelper testhelper;
     const irr::io::path mappingsFileName = "testactionmappings.yml";
     irr::core::stringc content = "---\n"
@@ -96,7 +96,7 @@ TEST_CASE("Action Mapping") {
         }
     }
 
-    SECTION("onEvent returns success of event procession") {
+    SECTION("onEvent returns success of event procession", "[unit]") {
         REQUIRE_FALSE(subject.onEvent(leftMouseButtonEvent));
         REQUIRE_FALSE(subject.onEvent(spaceBarEvent));
 

--- a/test/input/EventReceiverTest.cpp
+++ b/test/input/EventReceiverTest.cpp
@@ -11,7 +11,7 @@ inline bool operator==(const irr::SEvent& lhs, const irr::SEvent& rhs) {
     return lhs.EventType == rhs.EventType;
 }
 
-TEST_CASE("Event Receiver") {
+TEST_CASE("Event Receiver", "[unit]") {
     Mock<leviathan::input::IEventConsumer> consumerMock;
     Fake(Method(consumerMock, onEvent));
     leviathan::input::EventReceiver subject;


### PR DESCRIPTION
Every TEST_CASE has now a tag marking it as either unit test or integration test (or none of them, that is also possible). Can help during development, to not run integration tests if unit tests are failing. Example for a test executer (using Clang for static code analysis (scan-build) and Ninja as maker):
``` bash
#!/bin/bash

if scan-build ninja -C _build unit_tests install; then
  pushd _build/Debug
  ./unit_tests [unit] $1 && \
    ./unit_tests [integration] $1 && \
    ./unit_tests ~[unit] ~[integration] $1
  popd
fi
```