### PR TITLE
Decouple file handling

### DIFF
--- a/source/Leviathan/LeviathanDevice.cpp
+++ b/source/Leviathan/LeviathanDevice.cpp
@@ -5,14 +5,10 @@
 namespace leviathan {
     LeviathanDevice::LeviathanDevice()
     : configuration_(),
-      graphicEngine_(irr::createDeviceEx(configuration_.getGraphicEngineParams())),
+      graphicEngine_(irr::createDeviceEx(configuration_.getGraphicEngineParams())), // TODO not longer necessary, change!
       timeControl_(),
       gameStateManager_(),
-      logger_(new leviathan::core::Logger(
-          graphicEngine_->getFileSystem(),
-          graphicEngine_->getTimer(),
-          LOG_FILE_NAME,
-          configuration_.getLoggingLevel())),
+      logger_(new leviathan::core::Logger(LOG_FILE_NAME, configuration_.getLoggingLevel())),
       randomizer_(),
       eventReceiver_(),
       actions_(eventReceiver_) {
@@ -26,19 +22,14 @@ namespace leviathan {
             graphicEngine_->drop();
     }
 
-    void LeviathanDevice::init(const irr::io::path& fileName) {
+    void LeviathanDevice::init(const irr::io::path& fileName) { // TODO: rework!
         configuration_.readFromFile(fileName, graphicEngine_->getFileSystem());
         delete logger_;
         graphicEngine_->closeDevice();
         graphicEngine_->drop();
         graphicEngine_ = irr::createDeviceEx(configuration_.getGraphicEngineParams());
         graphicEngine_->setEventReceiver(&eventReceiver_);
-        logger_ = new leviathan::core::Logger(
-            graphicEngine_->getFileSystem(),
-            graphicEngine_->getTimer(),
-            LOG_FILE_NAME,
-            configuration_.getLoggingLevel(),
-            /*append = */ true);
+        logger_ = new leviathan::core::Logger(LOG_FILE_NAME, configuration_.getLoggingLevel(), /*append = */ true);
     }
 
     void LeviathanDevice::run() {

--- a/source/Leviathan/LeviathanDevice.cpp
+++ b/source/Leviathan/LeviathanDevice.cpp
@@ -4,32 +4,24 @@
 
 namespace leviathan {
     LeviathanDevice::LeviathanDevice()
-    : configuration_(),
-      graphicEngine_(irr::createDeviceEx(configuration_.getGraphicEngineParams())), // TODO not longer necessary, change!
-      timeControl_(),
-      gameStateManager_(),
-      logger_(new leviathan::core::Logger(LOG_FILE_NAME, configuration_.getLoggingLevel())),
-      randomizer_(),
-      eventReceiver_(),
+    : logger_(new leviathan::core::Logger(LOG_FILE_NAME, configuration_.getLoggingLevel())),
       actions_(eventReceiver_) {
-          randomizer_.start(static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count()));
-      }
-
-    LeviathanDevice::~LeviathanDevice() {
-        if (logger_)
-            delete logger_;
-        if (graphicEngine_)
-            graphicEngine_->drop();
+        randomizer_.start(static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count()));
     }
 
-    void LeviathanDevice::init(const irr::io::path& fileName) { // TODO: rework!
+    LeviathanDevice::~LeviathanDevice() {
+        if (graphicEngine_)
+            graphicEngine_->drop();
+        if (logger_)
+            delete logger_;
+    }
+
+    void LeviathanDevice::init(const irr::io::path& fileName) {
         configuration_.readFromFile(fileName);
         delete logger_;
-        graphicEngine_->closeDevice();
-        graphicEngine_->drop();
+        logger_ = new leviathan::core::Logger(LOG_FILE_NAME, configuration_.getLoggingLevel(), /*append = */ true);
         graphicEngine_ = irr::createDeviceEx(configuration_.getGraphicEngineParams());
         graphicEngine_->setEventReceiver(&eventReceiver_);
-        logger_ = new leviathan::core::Logger(LOG_FILE_NAME, configuration_.getLoggingLevel(), /*append = */ true);
     }
 
     void LeviathanDevice::run() {

--- a/source/Leviathan/LeviathanDevice.cpp
+++ b/source/Leviathan/LeviathanDevice.cpp
@@ -4,21 +4,23 @@
 
 namespace leviathan {
     LeviathanDevice::LeviathanDevice()
-    : logger_(new leviathan::core::Logger(LOG_FILE_NAME, configuration_.getLoggingLevel())),
-      actions_(eventReceiver_) {
+    : actions_(eventReceiver_) {
         randomizer_.start(static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count()));
     }
 
     LeviathanDevice::~LeviathanDevice() {
-        if (graphicEngine_)
+        if (graphicEngine_) {
             graphicEngine_->drop();
-        if (logger_)
+            graphicEngine_ = nullptr;
+        }
+        if (logger_) {
             delete logger_;
+            logger_ = nullptr;
+        }
     }
 
     void LeviathanDevice::init(const irr::io::path& fileName) {
         configuration_.readFromFile(fileName);
-        delete logger_;
         logger_ = new leviathan::core::Logger(LOG_FILE_NAME, configuration_.getLoggingLevel(), /*append = */ true);
         graphicEngine_ = irr::createDeviceEx(configuration_.getGraphicEngineParams());
         graphicEngine_->setEventReceiver(&eventReceiver_);

--- a/source/Leviathan/LeviathanDevice.cpp
+++ b/source/Leviathan/LeviathanDevice.cpp
@@ -23,7 +23,7 @@ namespace leviathan {
     }
 
     void LeviathanDevice::init(const irr::io::path& fileName) { // TODO: rework!
-        configuration_.readFromFile(fileName, graphicEngine_->getFileSystem());
+        configuration_.readFromFile(fileName);
         delete logger_;
         graphicEngine_->closeDevice();
         graphicEngine_->drop();

--- a/source/Leviathan/LeviathanDevice.h
+++ b/source/Leviathan/LeviathanDevice.h
@@ -95,13 +95,13 @@ namespace leviathan {
         input::EventReceiver& EventReceiver();
 
     private:
-        core::Configuration configuration_;
-        irr::IrrlichtDevice* graphicEngine_;
-        core::TimeControl timeControl_;
-        core::GameStateManager gameStateManager_;
+        core::Configuration configuration_ = core::Configuration();
+        irr::IrrlichtDevice* graphicEngine_ = nullptr;
+        core::TimeControl timeControl_ = core::TimeControl();
+        core::GameStateManager gameStateManager_ = core::GameStateManager();
         core::Logger* logger_;
-        core::Randomizer randomizer_;
-        input::EventReceiver eventReceiver_;
+        core::Randomizer randomizer_ = core::Randomizer();
+        input::EventReceiver eventReceiver_ = input::EventReceiver();
         input::Actions actions_;
 
         friend TesthelperLeviathanDevice::LeviathanDeviceWithIrrlichtMock;  // now Irrlicht can be mocked in unit tests

--- a/source/Leviathan/LeviathanDevice.h
+++ b/source/Leviathan/LeviathanDevice.h
@@ -48,7 +48,7 @@ namespace leviathan {
         /*! \brief Lädt die Konfiguration aus der angegebenen Datei und initialisiert alle Engine-Bestandteile damit.
          *  \param filename: Konfigdateiname
          */
-        void init(const irr::io::path& fileName);
+        void init(const irr::io::path& fileName); // FIXME:: use ctor. that's what they are for.
 
         /*! \brief Der eigentliche Game-Loop.
          *         Diese Methode kümmert sich um das Aktualisieren und Zeichnen des aktuellen Spielzustandes,
@@ -95,11 +95,11 @@ namespace leviathan {
         input::EventReceiver& EventReceiver();
 
     private:
+        core::Logger* logger_ = nullptr;
         core::Configuration configuration_ = core::Configuration();
         irr::IrrlichtDevice* graphicEngine_ = nullptr;
         core::TimeControl timeControl_ = core::TimeControl();
         core::GameStateManager gameStateManager_ = core::GameStateManager();
-        core::Logger* logger_;
         core::Randomizer randomizer_ = core::Randomizer();
         input::EventReceiver eventReceiver_ = input::EventReceiver();
         input::Actions actions_;

--- a/source/Leviathan/core/Configuration.h
+++ b/source/Leviathan/core/Configuration.h
@@ -35,9 +35,8 @@ namespace leviathan {
 
             /*! \brief Liest eine Konfigdatei aus und schreibt die Werte ins System.
              *  \param filename: Konfigdateiname
-             *  \param fileSystem: Zeiger auf ein Irrlicht-Dateisystem
              */
-            void readFromFile(const irr::io::path& fileName, irr::io::IFileSystem* fileSystem = nullptr);
+            void readFromFile(const irr::io::path& fileName);
 
             /*! \brief Schreibt die Werte aus dem System in eine Konfigdatei.
              *  \param filename: Konfigdateiname
@@ -93,7 +92,7 @@ namespace leviathan {
                                                                    {"DEBUG", Logger::Level::DEBUG},
                                                                    {"DETAIL", Logger::Level::DETAIL}};
 
-            void generateContent(const irr::io::path& fileName, irr::io::IFileSystem* fileSystem);
+            void generateContent(const irr::io::path& fileName);
             const irr::core::stringc getItem(
                 const irr::core::stringc& section,
                 const irr::core::stringc& key,

--- a/source/Leviathan/core/Configuration.h
+++ b/source/Leviathan/core/Configuration.h
@@ -40,9 +40,8 @@ namespace leviathan {
 
             /*! \brief Schreibt die Werte aus dem System in eine Konfigdatei.
              *  \param filename: Konfigdateiname
-             *  \param fileSystem: Zeiger auf ein Irrlicht-Dateisystem
              */
-            // void writeToFile(const irr::io::path& fileName, irr::io::IFileSystem* fileSystem = 0);
+            // void writeToFile(const irr::io::path& fileName);
 
             /*! \brief Gibt eine Sammlung von Parametern zur Erstellung eines Irrlicht-Device zurück.
              *  \return Parametersammlung

--- a/source/Leviathan/core/GameStateManager.cpp
+++ b/source/Leviathan/core/GameStateManager.cpp
@@ -1,9 +1,12 @@
 #include "GameStateManager.h"
 #include <iterator>
+#include <stdexcept>
 
 namespace leviathan {
     namespace core {
         void GameStateManager::add(IGameState& gameState, uint32_t id) {
+            if (id == NO_STATE_ACTIVE)
+                throw std::invalid_argument("0xffffffff is the only value not allowed as an ID here, sorry!");
             states_[id] = &gameState;
         }
 
@@ -30,13 +33,13 @@ namespace leviathan {
 
         void GameStateManager::update(const float elapsedSeconds) {
             uint32_t id = getActiveStateID();
-            if (id != 0xffffffff)
+            if (id != NO_STATE_ACTIVE)
                 states_[id]->update(elapsedSeconds);
         }
 
         void GameStateManager::draw() {
             uint32_t id = getActiveStateID();
-            if (id != 0xffffffff)
+            if (id != NO_STATE_ACTIVE)
                 states_[id]->draw();
         }
 
@@ -45,7 +48,7 @@ namespace leviathan {
         }
 
         uint32_t GameStateManager::getActiveStateID() {
-            return runningStateIDs_.empty() ? 0xffffffff : runningStateIDs_.front();
+            return runningStateIDs_.empty() ? NO_STATE_ACTIVE : runningStateIDs_.front();
         }
     }
 }

--- a/source/Leviathan/core/GameStateManager.h
+++ b/source/Leviathan/core/GameStateManager.h
@@ -73,6 +73,7 @@ namespace leviathan {
         private:
             std::map<uint32_t, IGameState*> states_ = std::map<uint32_t, IGameState*>();
             std::list<uint32_t> runningStateIDs_ = std::list<uint32_t>();
+            const uint32_t NO_STATE_ACTIVE = 0xffffffff;
         };
     }
 }

--- a/source/Leviathan/core/Logger.cpp
+++ b/source/Leviathan/core/Logger.cpp
@@ -1,22 +1,18 @@
 #include "Logger.h"
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
 
 namespace leviathan {
     namespace core {
 
-        Logger::Logger(
-            irr::io::IFileSystem* fileSystem,
-            irr::ITimer* clock,
-            const irr::io::path& fileName,
-            const Level globalLogLevel,
-            const bool append)
+        Logger::Logger(const irr::io::path& fileName, const Level globalLogLevel, const bool append)
         : text("LogLevel: "),
           fileName_(fileName),
-          fileSystem_(fileSystem),
-          clock_(clock),
+          logFile_(),
           globalLogLevel_(globalLogLevel) {
-            if (!fileSystem_ || !clock_)
-                exit(1);
-            fileSystem_->grab();
             openLogFile(append);
             addLogLevelName(text, globalLogLevel_);
             write();
@@ -24,7 +20,6 @@ namespace leviathan {
 
         Logger::~Logger() {
             closeLogFile();
-            fileSystem_->drop();
         }
 
         void Logger::write(const Level logLevel) {
@@ -35,29 +30,24 @@ namespace leviathan {
                 addLogLevelName(logline, logLevel);
                 logline += "] ";
                 logline += text;
-                logline += "\r\n";
-                logFile_->write(logline.c_str(), logline.size());
+                logFile_ << logline.c_str() << std::endl;
             }
-        }
-
-        void Logger::flush() {
-            closeLogFile();
-            openLogFile();
         }
 
         /* private: */
 
         void Logger::openLogFile(const bool append) {
-            logFile_ = fileSystem_->createAndWriteFile(fileName_, append);
-            if (!logFile_)
+            auto mode = std::fstream::out;
+            if (append)
+                mode |= std::fstream::app;
+            logFile_.open (fileName_.c_str(), mode);
+            if (!logFile_.is_open())
                 exit(1);
         }
 
         void Logger::closeLogFile() {
-            if (logFile_) {
-                logFile_->drop();
-                logFile_ = nullptr;
-            }
+            if (logFile_.is_open())
+                logFile_.close();
         }
 
         void Logger::addLogLevelName(irr::core::stringc& txt, const Level logLevel) {
@@ -80,24 +70,10 @@ namespace leviathan {
         }
 
         void Logger::addTimeStamp(irr::core::stringc& txt) {
-            auto now = clock_->getRealTimeAndDate();
-            addNumberWithLeadingZero(txt, now.Day);
-            txt += ".";
-            addNumberWithLeadingZero(txt, now.Month);
-            txt += ".";
-            txt += now.Year;
-            txt += " ";
-            addNumberWithLeadingZero(txt, now.Hour);
-            txt += ":";
-            addNumberWithLeadingZero(txt, now.Minute);
-            txt += ":";
-            addNumberWithLeadingZero(txt, now.Second);
-        }
-
-        void Logger::addNumberWithLeadingZero(irr::core::stringc& txt, const uint32_t number) {
-            if (number < 10)
-                txt += '0';
-            txt += number;
+            auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+            std::stringstream ss;
+            ss << std::put_time(std::localtime(&now), "%d.%m.%Y %H:%M:%S");
+            txt += ss.str().c_str();
         }
     }
 }

--- a/source/Leviathan/core/Logger.cpp
+++ b/source/Leviathan/core/Logger.cpp
@@ -37,10 +37,10 @@ namespace leviathan {
         /* private: */
 
         void Logger::openLogFile(const bool append) {
-            auto mode = std::fstream::out;
+            std::ios_base::openmode mode = std::fstream::out;
             if (append)
                 mode |= std::fstream::app;
-            logFile_.open (fileName_.c_str(), mode);
+            logFile_.open(fileName_.c_str(), mode);
             if (!logFile_.is_open())
                 exit(1);
         }

--- a/source/Leviathan/core/Logger.h
+++ b/source/Leviathan/core/Logger.h
@@ -8,6 +8,7 @@
 
 #include "irrlicht.h"
 #include <cstdint>
+#include <fstream>
 
 namespace leviathan {
     namespace core {
@@ -42,19 +43,12 @@ namespace leviathan {
             irr::core::stringc text;
 
             /*! \brief Konstruktor.
-             *  \param fileSystem: Zeiger auf ein Irrlicht-Dateisystem
-             *  \param clock: Zeiger auf das Irrlicht-Zeitsystem
              *  \param fileName: Logdateiname
              *  \param globalLogLevel: Informationen bis zu diesem Level landen in der Logdatei, alles darüber nicht.
              *  \param append: Wenn `false`, dann wird immer eine neue Logdatei erzeugt. Wenn `true` wird angehängt,
              *         sofern vorhanden.
              */
-            Logger(
-                irr::io::IFileSystem* fileSystem,
-                irr::ITimer* clock,
-                const irr::io::path& fileName,
-                const Level globalLogLevel,
-                const bool append = false);
+            Logger(const irr::io::path& fileName, const Level globalLogLevel, const bool append = false);
 
             /*! \brief Destruktor.
              */
@@ -71,27 +65,15 @@ namespace leviathan {
              */
             void write(const Level logLevel = Level::INFO);
 
-            /*! \brief Schreibt den Logdatei-Buffer auf die Platte.
-             *  \attention Dies schließt die Logdatei und öffnet sie erneut! (Keine Irrlicht-Implementation dafür
-             *             vorhanden)
-             *             Nur in Ausnahmefällen benutzen, da die Gefahr besteht, dass sich Prozesse wie z.B. ein
-             *             Virenscanner die Logdatei greifen, und Leviathan plötzlich keinen Zugriff mehr auf seine
-             *             Logdatei hat! (Das bedeutet: sofortiger Programmabsturz)
-             */
-            void flush();
-
         private:
             irr::io::path fileName_;  // Logdateiname
-            irr::io::IFileSystem* fileSystem_;  // Irrlicht-Dateisystem
-            irr::ITimer* clock_;  // Irrlicht-Zeitsystem
-            irr::io::IWriteFile* logFile_ = nullptr;  // Logdatei
+            std::fstream logFile_;  // Stream auf die Logdatei
             Level globalLogLevel_;  // Globales LogLevel
 
             inline void openLogFile(const bool append = true);
             inline void closeLogFile();
             inline static void addLogLevelName(irr::core::stringc& txt, const Level logLevel);
             inline void addTimeStamp(irr::core::stringc& txt);
-            inline static void addNumberWithLeadingZero(irr::core::stringc& txt, const uint32_t number);
         };
     }
 }

--- a/test/core/ConfigurationTest.cpp
+++ b/test/core/ConfigurationTest.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Configuration: read values", "[unit]") {
         content += "[camera]\n";
         content += "far_value = 300.0\n";
         testhelper.writeFile(configFileName, content);
-        subject.readFromFile(configFileName, testhelper.getFileSystem());
+        subject.readFromFile(configFileName);
         REQUIRE(subject.getGraphicEngineParams().WindowSize.Width == 1366);
         REQUIRE(subject.getGraphicEngineParams().WindowSize.Height == 768);
         REQUIRE(subject.getGraphicEngineParams().Bits == 32);
@@ -49,14 +49,14 @@ TEST_CASE("Configuration: read values", "[unit]") {
 
         SECTION("reading again overwrites changes") {
             testhelper.writeFile(configFileName, "[video]\ncolor_depth=42\n");
-            subject.readFromFile(configFileName, testhelper.getFileSystem());
+            subject.readFromFile(configFileName);
             REQUIRE(subject.getGraphicEngineParams().Bits == 42);
         }
     }
     SECTION("it uses default values") {
         SECTION("if keys are missing") {
             testhelper.writeFile(configFileName, "");
-            subject.readFromFile(configFileName, testhelper.getFileSystem());
+            subject.readFromFile(configFileName);
             REQUIRE(subject.getGraphicEngineParams().WindowSize.Width == 800);
             REQUIRE(subject.getGraphicEngineParams().WindowSize.Height == 600);
             REQUIRE(subject.getGraphicEngineParams().Bits == 16);
@@ -72,23 +72,23 @@ TEST_CASE("Configuration: read values", "[unit]") {
             content += "[video]\n";
             content += "driver=UNKNOWN\n";
             testhelper.writeFile(configFileName, content);
-            subject.readFromFile(configFileName, testhelper.getFileSystem());
+            subject.readFromFile(configFileName);
             REQUIRE(subject.getGraphicEngineParams().DriverType == irr::video::EDT_SOFTWARE);
             REQUIRE(subject.getLoggingLevel() == leviathan::core::Logger::Level::INFO);
         }
         SECTION("if file is missing") {
-            subject.readFromFile("totally_nonexisting_file", testhelper.getFileSystem());
+            subject.readFromFile("totally_nonexisting_file");
             REQUIRE(subject.getGraphicEngineParams().Bits == 16);
         }
     }
     SECTION("# and ; are valid comment indicators") {
         testhelper.writeFile(configFileName, "[test_section]\n;test_value=1\n#test_value=2\ntest_value=3\n");
-        subject.readFromFile(configFileName, testhelper.getFileSystem());
+        subject.readFromFile(configFileName);
         REQUIRE(subject.getInt("test_section", "test_value") == 3);
     }
     SECTION("erroneous section will be ignored") {
         testhelper.writeFile(configFileName, "[s 1]\nv=42\n[s\n2]\nv=42\n[s3]v=42\n[[s4]s4]\nv=42\n[s]5]\nv=42\n");
-        subject.readFromFile(configFileName, testhelper.getFileSystem());
+        subject.readFromFile(configFileName);
         REQUIRE(subject.getInt("s1", "v") == 0);
         REQUIRE(subject.getInt("s2", "v") == 0);
         REQUIRE(subject.getInt("s3", "v") == 0);
@@ -97,7 +97,7 @@ TEST_CASE("Configuration: read values", "[unit]") {
     }
     SECTION("erroneous key-value-pair will be ignored") {
         testhelper.writeFile(configFileName, "[s]\nv 1=42\nv2 == 42\nv3 42\nv4=\nv[5=42\n");
-        subject.readFromFile(configFileName, testhelper.getFileSystem());
+        subject.readFromFile(configFileName);
         REQUIRE(subject.getInt("s", "v1") == 0);
         REQUIRE(subject.getInt("s", "v2") == 0);
         REQUIRE(subject.getInt("s", "v3") == 0);

--- a/test/core/GameStateManagerTest.cpp
+++ b/test/core/GameStateManagerTest.cpp
@@ -2,6 +2,7 @@
 #include "../../source/Leviathan/core/IGameState.h"
 #include "catch.hpp"
 #include "fakeit.hpp"
+#include <stdexcept>
 
 using namespace fakeit;
 
@@ -29,6 +30,10 @@ TEST_CASE("GameStateManager: add game states", "[unit]") {
         REQUIRE(subject.getGameStateCount() == 3);
         subject.add(play, STATE_START);
         REQUIRE(subject.getGameStateCount() == 3);
+    }
+
+    SECTION("internal ID is not allowed") {
+        REQUIRE_THROWS_AS(subject.add(start, 0xffffffff), std::invalid_argument);
     }
 }
 

--- a/test/core/LoggerTest.cpp
+++ b/test/core/LoggerTest.cpp
@@ -7,51 +7,35 @@
 TEST_CASE("Logger: init", "[unit]") {
     Testhelper testhelper;
     const irr::io::path logFileName = "testlogfile.log";
-    leviathan::core::Logger sample(
-        testhelper.getFileSystem(),
-        testhelper.getGraphicEngine()->getTimer(),
-        logFileName,
-        leviathan::core::Logger::Level::INFO);
-    sample.flush();
 
     SECTION("it creates a logfile") {
+        leviathan::core::Logger sample(logFileName, leviathan::core::Logger::Level::INFO);
         REQUIRE(testhelper.existFile(logFileName));
 
         uint32_t size = testhelper.getFileSize(logFileName);
 
         SECTION("by overwriting an existing logfile") {
-            leviathan::core::Logger subject(
-                testhelper.getFileSystem(),
-                testhelper.getGraphicEngine()->getTimer(),
-                logFileName,
-                leviathan::core::Logger::Level::INFO);
-            subject.flush();
+            leviathan::core::Logger subject(logFileName, leviathan::core::Logger::Level::INFO);
             uint32_t newSize = testhelper.getFileSize(logFileName);
             REQUIRE(newSize == size);
         }
+
         SECTION("by appending to an existing logfile") {
-            leviathan::core::Logger subject(
-                testhelper.getFileSystem(),
-                testhelper.getGraphicEngine()->getTimer(),
-                logFileName,
-                leviathan::core::Logger::Level::INFO,
-                true);
-            subject.flush();
+            leviathan::core::Logger subject(logFileName, leviathan::core::Logger::Level::INFO, true);
             uint32_t newSize = testhelper.getFileSize(logFileName);
             REQUIRE(newSize == size * 2);
         }
+
         SECTION("and writes the global logging level into it") {
             irr::core::stringc content = testhelper.readFile(logFileName);
             REQUIRE(content.find("] LogLevel: Info") > -1);
         }
     }
+
     SECTION("multiple logfiles may exist") {
         const irr::io::path anotherLogFileName = "testlogfile2.log";
-        leviathan::core::Logger sample2(
-            testhelper.getFileSystem(),
-            testhelper.getGraphicEngine()->getTimer(),
-            anotherLogFileName,
-            leviathan::core::Logger::Level::INFO);
+        leviathan::core::Logger sample(logFileName, leviathan::core::Logger::Level::INFO);
+        leviathan::core::Logger sample2(anotherLogFileName, leviathan::core::Logger::Level::INFO);
         REQUIRE(testhelper.existFile(logFileName));
         REQUIRE(testhelper.existFile(anotherLogFileName));
     }
@@ -62,43 +46,34 @@ TEST_CASE("Logger: logging", "[unit]") {
     const irr::io::path logFileName = "testlogfile.log";
 
     SECTION("it writes text into the logfile") {
-        leviathan::core::Logger subject(
-            testhelper.getFileSystem(),
-            testhelper.getGraphicEngine()->getTimer(),
-            logFileName,
-            leviathan::core::Logger::Level::INFO);
+        leviathan::core::Logger subject(logFileName, leviathan::core::Logger::Level::INFO);
         subject.text = "Kilroy wuz here";
         subject.write();
-        subject.flush();
         irr::core::stringc content = testhelper.readFile(logFileName);
         REQUIRE(content.find("] Kilroy wuz here") > -1);
 
         SECTION("with special characters") {
             subject.text = "german umlauts: äöüß, some other things: >_%&$§?!@|";
             subject.write();
-            subject.flush();
             content = testhelper.readFile(logFileName);
             REQUIRE(content.find("äöüß") > -1);
             REQUIRE(content.find(">_%&$§?!@|") > -1);
         }
+
         SECTION("over multiple lines") {
             subject.text = "one line.";
             subject.write();
             subject.text = "another line.";
             subject.write();
-            subject.flush();
             content = testhelper.readFile(logFileName);
             int32_t firstIndex = content.find("line.");
             REQUIRE(firstIndex > -1);
             REQUIRE(content.find("line.", static_cast<uint32_t>(firstIndex) + 1) > -1);
         }
     }
+
     SECTION("it handles different logLevels", "[unit]") {
-        leviathan::core::Logger subject(
-            testhelper.getFileSystem(),
-            testhelper.getGraphicEngine()->getTimer(),
-            logFileName,
-            leviathan::core::Logger::Level::DETAIL);
+        leviathan::core::Logger subject(logFileName, leviathan::core::Logger::Level::DETAIL);
         subject.text = "a line just for information";
         subject.write(leviathan::core::Logger::Level::INFO);
         subject.text = "a line full of details";
@@ -107,7 +82,6 @@ TEST_CASE("Logger: logging", "[unit]") {
         subject.write(leviathan::core::Logger::Level::DEBUG);
         subject.text = "a line hopefully never ever written";
         subject.write(leviathan::core::Logger::Level::ALL);
-        subject.flush();
         irr::core::stringc content = testhelper.readFile(logFileName);
         REQUIRE(content.find("information") > -1);
         REQUIRE(content.find("details") > -1);


### PR DESCRIPTION
This PR will
- use std::fstream instead of Irrlicht file operations in Configuration
- use std::fstream instead of Irrlicht file operations in Logger
- refactor LeviathanDevice construction/destruction
- GameStateManager will now raise on invalid state ID

Will close #111 