### PR TITLE
Tidy up logger

### DIFF
--- a/source/Leviathan/LeviathanDevice.cpp
+++ b/source/Leviathan/LeviathanDevice.cpp
@@ -12,7 +12,7 @@ namespace leviathan {
         randomizer_.start(static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count()));
         graphicEngine_ = irr::createDeviceEx(configuration_.getGraphicEngineParams());
         if (graphicEngine_ == nullptr) {
-            logger_.text = "could not initialize Irrlicht Engine!";
+            logger_.text << "could not initialize Irrlicht Engine!";
             logger_.write(core::Logger::Level::INFO);
             throw std::runtime_error("could not initialize Irrlicht Engine!");
         }

--- a/source/Leviathan/core/GameStateManager.cpp
+++ b/source/Leviathan/core/GameStateManager.cpp
@@ -12,9 +12,7 @@ namespace leviathan {
             if (states_.find(id) == states_.end()) {
                 states_[id] = &gameState;
             } else {
-                logger_.text = "[Warning] - GameStateManager - cannot add state ";
-                logger_.text += id;
-                logger_.text += ", already exists!";
+                logger_.text << "[Warning] - GameStateManager - cannot add state " << id << ", already exists!";
                 logger_.write(Logger::Level::DEBUG);
             }
         }
@@ -51,9 +49,7 @@ namespace leviathan {
 
         bool GameStateManager::isUnknownState(const uint32_t id) const {
             if (states_.find(id) == states_.end()) {
-                logger_.text = "[Warning] - GameStateManager - unknown state ";
-                logger_.text += id;
-                logger_.text += " requested!";
+                logger_.text << "[Warning] - GameStateManager - unknown state " << id << " requested!";
                 logger_.write(Logger::Level::DEBUG);
                 return true;
             }
@@ -62,9 +58,7 @@ namespace leviathan {
 
         bool GameStateManager::isAlreadyActive(const uint32_t id) const {
             if (getActiveStateID() == id) {
-                logger_.text = "[Warning] - GameStateManager - active state ";
-                logger_.text += id;
-                logger_.text += " requested!";
+                logger_.text << "[Warning] - GameStateManager - active state " << id << " requested!";
                 logger_.write(Logger::Level::DEBUG);
                 return true;
             }
@@ -79,9 +73,8 @@ namespace leviathan {
             if (runningStateIDs_.size() < 2 || isSecondOnStack(id))
                 return false;
             if (isInStack(id)) {
-                logger_.text = "[Warning] - GameStateManager - requested state ";
-                logger_.text += id;
-                logger_.text += " is too deep down the stack!";
+                logger_.text << "[Warning] - GameStateManager - requested state " << id
+                             << " is too deep down the stack!";
                 logger_.write(Logger::Level::DEBUG);
                 return true;
             }

--- a/source/Leviathan/core/Logger.cpp
+++ b/source/Leviathan/core/Logger.cpp
@@ -7,13 +7,11 @@
 
 namespace leviathan {
     namespace core {
-
         Logger::Logger(const irr::io::path& fileName, const Level globalLogLevel, const bool append)
         : text("LogLevel: "),
-          fileName_(fileName),
           logFile_(),
           globalLogLevel_(globalLogLevel) {
-            openLogFile(append);
+            openLogFile(fileName, append);
             addLogLevelName(text, globalLogLevel_);
             write();
         }
@@ -37,7 +35,7 @@ namespace leviathan {
 
         /* private: */
 
-        void Logger::openLogFile(const bool append) {
+        void Logger::openLogFile(const irr::io::path& fileName, const bool append) {
             std::ios_base::openmode mode = std::fstream::out;
             if (append)
                 mode |= std::fstream::app;

--- a/source/Leviathan/core/Logger.cpp
+++ b/source/Leviathan/core/Logger.cpp
@@ -1,18 +1,15 @@
 #include "Logger.h"
 #include <chrono>
 #include <ctime>
-#include <iomanip>
 #include <sstream>
-
 
 namespace leviathan {
     namespace core {
         Logger::Logger(const char* fileName, const Level globalLogLevel, const bool append)
-        : text("LogLevel: "),
-          logFile_(),
+        : logFile_(),
           globalLogLevel_(globalLogLevel) {
             openLogFile(fileName, append);
-            addLogLevelName(text, globalLogLevel_);
+            text << "LogLevel: " << logLevelName(globalLogLevel_);
             write();
         }
 
@@ -23,15 +20,12 @@ namespace leviathan {
 
         void Logger::write(const Level logLevel) {
             if (logLevel <= globalLogLevel_) {
-                irr::core::stringc logline("");
-                addTimeStamp(logline);
-                logline += " [";
-                addLogLevelName(logline, logLevel);
-                logline += "] ";
-                logline += text;
-                logFile_ << logline.c_str() << std::endl;
+                std::ostringstream loglinePrefix;
+                addTimeStamp(loglinePrefix);
+                loglinePrefix << " [" << logLevelName(logLevel) << "] ";
+                logFile_ << loglinePrefix.str() << text.str() << std::endl;
             }
-            text = "";
+            text.str(std::string());
         }
 
         /* private: */
@@ -45,30 +39,24 @@ namespace leviathan {
                 exit(1);
         }
 
-        void Logger::addLogLevelName(irr::core::stringc& txt, const Level logLevel) {
+        std::string Logger::logLevelName(const Level logLevel) {
             switch (logLevel) {
             case Level::INFO:
-                txt += "Info";
-                break;
+                return "Info";
             case Level::DETAIL:
-                txt += "Detail";
-                break;
+                return "Detail";
             case Level::DEBUG:
-                txt += "Debug";
-                break;
+                return "Debug";
             case Level::ALL:
-                txt += "All";
-                break;
+                return "All";
             default:
-                txt += "unknown log level!";
+                return "unknown log level!";
             }
         }
 
-        void Logger::addTimeStamp(irr::core::stringc& txt) {
+        void Logger::addTimeStamp(std::ostringstream& txt) {
             auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-            std::stringstream ss;
-            ss << std::put_time(std::localtime(&now), "%d.%m.%Y %H:%M:%S");
-            txt += ss.str().c_str();
+            txt << std::put_time(std::localtime(&now), "%d.%m.%Y %H:%M:%S");
         }
     }
 }

--- a/source/Leviathan/core/Logger.cpp
+++ b/source/Leviathan/core/Logger.cpp
@@ -7,7 +7,7 @@
 
 namespace leviathan {
     namespace core {
-        Logger::Logger(const irr::io::path& fileName, const Level globalLogLevel, const bool append)
+        Logger::Logger(const char* fileName, const Level globalLogLevel, const bool append)
         : text("LogLevel: "),
           logFile_(),
           globalLogLevel_(globalLogLevel) {
@@ -36,11 +36,11 @@ namespace leviathan {
 
         /* private: */
 
-        void Logger::openLogFile(const irr::io::path& fileName, const bool append) {
+        void Logger::openLogFile(const char* fileName, const bool append) {
             std::ios_base::openmode mode = std::fstream::out;
             if (append)
                 mode |= std::fstream::app;
-            logFile_.open(fileName.c_str(), mode);
+            logFile_.open(fileName, mode);
             if (!logFile_.is_open())
                 exit(1);
         }

--- a/source/Leviathan/core/Logger.cpp
+++ b/source/Leviathan/core/Logger.cpp
@@ -17,7 +17,8 @@ namespace leviathan {
         }
 
         Logger::~Logger() {
-            closeLogFile();
+            if (logFile_.is_open())
+                logFile_.close();
         }
 
         void Logger::write(const Level logLevel) {
@@ -39,14 +40,9 @@ namespace leviathan {
             std::ios_base::openmode mode = std::fstream::out;
             if (append)
                 mode |= std::fstream::app;
-            logFile_.open(fileName_.c_str(), mode);
+            logFile_.open(fileName.c_str(), mode);
             if (!logFile_.is_open())
                 exit(1);
-        }
-
-        void Logger::closeLogFile() {
-            if (logFile_.is_open())
-                logFile_.close();
         }
 
         void Logger::addLogLevelName(irr::core::stringc& txt, const Level logLevel) {

--- a/source/Leviathan/core/Logger.h
+++ b/source/Leviathan/core/Logger.h
@@ -6,10 +6,11 @@
 #ifndef LEVIATHAN_CORE_LOGGER_H
 #define LEVIATHAN_CORE_LOGGER_H
 
-#include "irrlicht.h"
 #include <cstdint>
 // #include <filesystem> // TODO: use this as soon as it is available in mingw!
 #include <fstream>
+#include <iomanip>
+#include <ostream>
 
 namespace leviathan {
     namespace core {
@@ -34,14 +35,10 @@ namespace leviathan {
                 ALL = 1000  //!< Alle verfügbaren Informationen
             };
 
-            /*! \brief Eine Zeile Text.
-             *  \details Da die Irrlicht-Strings bereits sehr mächtige Append-Methoden haben und wir uns den Aufwand
-             *           echt sparen können, wird dieser Member ausnahmsweise ohne Getter oder Setter zugänglich
-             *           gemacht.
+            /*! \brief Zu schreibender Text.
              *  \note Wird geleert sobald er in die Logdatei geschrieben wurde.
-             *  \attention Erst initialisieren, dann anhängen!
              */
-            irr::core::stringc text;
+            std::ostringstream text = std::ostringstream();
 
             /*! \brief Konstruktor.
              *  \param fileName: Logdateiname
@@ -68,12 +65,12 @@ namespace leviathan {
             void write(const Level logLevel = Level::INFO);
 
         private:
-            std::fstream logFile_;  // Stream auf die Logdatei
-            Level globalLogLevel_;  // Globales LogLevel
+            std::fstream logFile_;
+            Level globalLogLevel_;
 
             inline void openLogFile(const char* fileName, const bool append = true);
-            inline static void addLogLevelName(irr::core::stringc& txt, const Level logLevel);
-            inline void addTimeStamp(irr::core::stringc& txt);
+            inline std::string logLevelName(const Level logLevel);
+            inline void addTimeStamp(std::ostringstream& txt);
         };
     }
 }

--- a/source/Leviathan/core/Logger.h
+++ b/source/Leviathan/core/Logger.h
@@ -8,6 +8,7 @@
 
 #include "irrlicht.h"
 #include <cstdint>
+// #include <filesystem> // TODO: use this as soon as it is available in mingw!
 #include <fstream>
 
 namespace leviathan {
@@ -48,7 +49,7 @@ namespace leviathan {
              *  \param append: Wenn `false`, dann wird immer eine neue Logdatei erzeugt. Wenn `true` wird angehängt,
              *         sofern vorhanden.
              */
-            Logger(const irr::io::path& fileName, const Level globalLogLevel, const bool append = false);
+            Logger(const char* fileName, const Level globalLogLevel, const bool append = false);
 
             /*! \brief Destruktor.
              */
@@ -70,7 +71,7 @@ namespace leviathan {
             std::fstream logFile_;  // Stream auf die Logdatei
             Level globalLogLevel_;  // Globales LogLevel
 
-            inline void openLogFile(const irr::io::path& fileName, const bool append = true);
+            inline void openLogFile(const char* fileName, const bool append = true);
             inline static void addLogLevelName(irr::core::stringc& txt, const Level logLevel);
             inline void addTimeStamp(irr::core::stringc& txt);
         };

--- a/source/Leviathan/core/Logger.h
+++ b/source/Leviathan/core/Logger.h
@@ -67,11 +67,10 @@ namespace leviathan {
             void write(const Level logLevel = Level::INFO);
 
         private:
-            irr::io::path fileName_;  // Logdateiname
             std::fstream logFile_;  // Stream auf die Logdatei
             Level globalLogLevel_;  // Globales LogLevel
 
-            inline void openLogFile(const bool append = true);
+            inline void openLogFile(const irr::io::path& fileName, const bool append = true);
             inline void closeLogFile();
             inline static void addLogLevelName(irr::core::stringc& txt, const Level logLevel);
             inline void addTimeStamp(irr::core::stringc& txt);

--- a/source/Leviathan/core/Logger.h
+++ b/source/Leviathan/core/Logger.h
@@ -71,7 +71,6 @@ namespace leviathan {
             Level globalLogLevel_;  // Globales LogLevel
 
             inline void openLogFile(const irr::io::path& fileName, const bool append = true);
-            inline void closeLogFile();
             inline static void addLogLevelName(irr::core::stringc& txt, const Level logLevel);
             inline void addTimeStamp(irr::core::stringc& txt);
         };

--- a/source/new_game_code/main.cpp
+++ b/source/new_game_code/main.cpp
@@ -17,7 +17,7 @@ int main() {
 
         game.transitTo(STATE_PLAY);
         gameEngine.run();
-    } catch (std::runtime_error) {
+    } catch (std::runtime_error& _) {
         return 1;
     }
     return 0;

--- a/test/LeviathanDeviceTest.cpp
+++ b/test/LeviathanDeviceTest.cpp
@@ -26,7 +26,7 @@ TEST_CASE("LeviathanDevice supporter", "[integration]") {
 
 TEST_CASE("LeviathanDevice main loop", "[integration]") {
     Testhelper testhelper;
-    const irr::io::path configFileName = "testconfigfile.ini";
+    const char* configFileName = "testconfigfile.ini";
     testhelper.writeFile(configFileName, "[video]\nmax_fps=100\nscreen_x=5\nscreen_y=5\n");
     TesthelperLeviathanDevice::LeviathanDeviceWithIrrlichtMock subject(configFileName);
     Mock<irr::ITimer> timerDouble;

--- a/test/core/ConfigurationTest.cpp
+++ b/test/core/ConfigurationTest.cpp
@@ -11,7 +11,7 @@
 
 TEST_CASE("Configuration: read values", "[unit]") {
     Testhelper testhelper;
-    const irr::io::path configFileName = "testconfigfile.ini";
+    const char* configFileName = "testconfigfile.ini";
 
     SECTION("all relevant values can be read") {
         irr::core::stringc content = "[general]\n";
@@ -51,7 +51,7 @@ TEST_CASE("Configuration: read values", "[unit]") {
 
 TEST_CASE("Configuration: default values", "[unit]") {
     Testhelper testhelper;
-    const irr::io::path configFileName = "testconfigfile.ini";
+    const char* configFileName = "testconfigfile.ini";
 
     SECTION("it has default values on unsuccessfull config file read") {
         leviathan::core::Configuration subject("");
@@ -79,7 +79,7 @@ TEST_CASE("Configuration: default values", "[unit]") {
 
 TEST_CASE("Configuration: file format", "[unit]") {
     Testhelper testhelper;
-    const irr::io::path configFileName = "testconfigfile.ini";
+    const char* configFileName = "testconfigfile.ini";
     leviathan::core::Configuration subject("");
 
     SECTION("# and ; are valid comment indicators") {

--- a/test/core/LoggerTest.cpp
+++ b/test/core/LoggerTest.cpp
@@ -1,8 +1,8 @@
 #include "../../source/Leviathan/core/Logger.h"
 #include "../helpers/Testhelper.h"
 #include "catch.hpp"
-#include "irrlicht.h"
 #include <cstdint>
+#include <string>
 
 TEST_CASE("Logger", "[unit]") {
     const char* logFileName = "testlogfile.log";
@@ -26,8 +26,8 @@ TEST_CASE("Logger", "[unit]") {
             }
 
             SECTION("and writes the global logging level into it") {
-                irr::core::stringc content = testhelper.readFile(logFileName);
-                REQUIRE(content.find("] LogLevel: Info") > -1);
+                std::string content = testhelper.readFile(logFileName);
+                REQUIRE_FALSE(content.find("] LogLevel: Info") == std::string::npos);
             }
         }
 
@@ -45,15 +45,15 @@ TEST_CASE("Logger", "[unit]") {
             leviathan::core::Logger subject(logFileName, leviathan::core::Logger::Level::INFO);
             subject.text = "Kilroy wuz here";
             subject.write();
-            irr::core::stringc content = testhelper.readFile(logFileName);
-            REQUIRE(content.find("] Kilroy wuz here") > -1);
+            std::string content = testhelper.readFile(logFileName);
+            REQUIRE_FALSE(content.find("] Kilroy wuz here") == std::string::npos);
 
             SECTION("with special characters") {
                 subject.text = "german umlauts: äöüß, some other things: >_%&$§?!@|";
                 subject.write();
                 content = testhelper.readFile(logFileName);
-                REQUIRE(content.find("äöüß") > -1);
-                REQUIRE(content.find(">_%&$§?!@|") > -1);
+                REQUIRE_FALSE(content.find("äöüß") == std::string::npos);
+                REQUIRE_FALSE(content.find(">_%&$§?!@|") == std::string::npos);
             }
 
             SECTION("over multiple lines") {
@@ -62,9 +62,9 @@ TEST_CASE("Logger", "[unit]") {
                 subject.text = "another line.";
                 subject.write();
                 content = testhelper.readFile(logFileName);
-                int32_t firstIndex = content.find("line.");
-                REQUIRE(firstIndex > -1);
-                REQUIRE(content.find("line.", static_cast<uint32_t>(firstIndex) + 1) > -1);
+                uint32_t firstIndex = content.find("line.");
+                REQUIRE_FALSE(firstIndex == std::string::npos);
+                REQUIRE_FALSE(content.find("line.", firstIndex + 1) == std::string::npos);
             }
 
             SECTION("and clears the text afterwards") {
@@ -84,11 +84,11 @@ TEST_CASE("Logger", "[unit]") {
             subject.write(leviathan::core::Logger::Level::DEBUG);
             subject.text = "a line hopefully never ever written";
             subject.write(leviathan::core::Logger::Level::ALL);
-            irr::core::stringc content = testhelper.readFile(logFileName);
-            REQUIRE(content.find("information") > -1);
-            REQUIRE(content.find("details") > -1);
-            REQUIRE_FALSE(content.find("debugging") > -1);
-            REQUIRE_FALSE(content.find("never ever") > -1);
+            std::string content = testhelper.readFile(logFileName);
+            REQUIRE_FALSE(content.find("information") == std::string::npos);
+            REQUIRE_FALSE(content.find("details") == std::string::npos);
+            REQUIRE(content.find("debugging") == std::string::npos);
+            REQUIRE(content.find("never ever") == std::string::npos);
         }
     }
 }

--- a/test/core/LoggerTest.cpp
+++ b/test/core/LoggerTest.cpp
@@ -43,13 +43,13 @@ TEST_CASE("Logger", "[unit]") {
     SECTION("logging") {
         SECTION("it writes text into the logfile") {
             leviathan::core::Logger subject(logFileName, leviathan::core::Logger::Level::INFO);
-            subject.text = "Kilroy wuz here";
+            subject.text << "Kilroy wuz here";
             subject.write();
             std::string content = testhelper.readFile(logFileName);
             REQUIRE(content.find("] Kilroy wuz here") != std::string::npos);
 
             SECTION("with special characters") {
-                subject.text = "german umlauts: äöüß, some other things: >_%&$§?!@|";
+                subject.text << "german umlauts: äöüß, some other things: >_%&$§?!@|";
                 subject.write();
                 content = testhelper.readFile(logFileName);
                 REQUIRE(content.find("äöüß") != std::string::npos);
@@ -57,9 +57,9 @@ TEST_CASE("Logger", "[unit]") {
             }
 
             SECTION("over multiple lines") {
-                subject.text = "one line.";
+                subject.text << "one line.";
                 subject.write();
-                subject.text = "another line.";
+                subject.text << "another line.";
                 subject.write();
                 content = testhelper.readFile(logFileName);
                 uint32_t firstIndex = content.find("line.");
@@ -68,21 +68,21 @@ TEST_CASE("Logger", "[unit]") {
             }
 
             SECTION("and clears the text afterwards") {
-                subject.text = "usefull information";
+                subject.text << "usefull information";
                 subject.write();
-                REQUIRE(subject.text.empty());
+                REQUIRE(subject.text.str().empty());
             }
         }
 
         SECTION("it handles different logLevels") {
             leviathan::core::Logger subject(logFileName, leviathan::core::Logger::Level::DETAIL);
-            subject.text = "a line just for information";
+            subject.text << "a line just for information";
             subject.write(leviathan::core::Logger::Level::INFO);
-            subject.text = "a line full of details";
+            subject.text << "a line full of details";
             subject.write(leviathan::core::Logger::Level::DETAIL);
-            subject.text = "a line for debugging";
+            subject.text << "a line for debugging";
             subject.write(leviathan::core::Logger::Level::DEBUG);
-            subject.text = "a line hopefully never ever written";
+            subject.text << "a line hopefully never ever written";
             subject.write(leviathan::core::Logger::Level::ALL);
             std::string content = testhelper.readFile(logFileName);
             REQUIRE(content.find("information") != std::string::npos);

--- a/test/core/LoggerTest.cpp
+++ b/test/core/LoggerTest.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Logger", "[unit]") {
 
             SECTION("and writes the global logging level into it") {
                 std::string content = testhelper.readFile(logFileName);
-                REQUIRE_FALSE(content.find("] LogLevel: Info") == std::string::npos);
+                REQUIRE(content.find("] LogLevel: Info") != std::string::npos);
             }
         }
 
@@ -46,14 +46,14 @@ TEST_CASE("Logger", "[unit]") {
             subject.text = "Kilroy wuz here";
             subject.write();
             std::string content = testhelper.readFile(logFileName);
-            REQUIRE_FALSE(content.find("] Kilroy wuz here") == std::string::npos);
+            REQUIRE(content.find("] Kilroy wuz here") != std::string::npos);
 
             SECTION("with special characters") {
                 subject.text = "german umlauts: äöüß, some other things: >_%&$§?!@|";
                 subject.write();
                 content = testhelper.readFile(logFileName);
-                REQUIRE_FALSE(content.find("äöüß") == std::string::npos);
-                REQUIRE_FALSE(content.find(">_%&$§?!@|") == std::string::npos);
+                REQUIRE(content.find("äöüß") != std::string::npos);
+                REQUIRE(content.find(">_%&$§?!@|") != std::string::npos);
             }
 
             SECTION("over multiple lines") {
@@ -63,8 +63,8 @@ TEST_CASE("Logger", "[unit]") {
                 subject.write();
                 content = testhelper.readFile(logFileName);
                 uint32_t firstIndex = content.find("line.");
-                REQUIRE_FALSE(firstIndex == std::string::npos);
-                REQUIRE_FALSE(content.find("line.", firstIndex + 1) == std::string::npos);
+                REQUIRE(firstIndex != std::string::npos);
+                REQUIRE(content.find("line.", firstIndex + 1) != std::string::npos);
             }
 
             SECTION("and clears the text afterwards") {
@@ -85,8 +85,8 @@ TEST_CASE("Logger", "[unit]") {
             subject.text = "a line hopefully never ever written";
             subject.write(leviathan::core::Logger::Level::ALL);
             std::string content = testhelper.readFile(logFileName);
-            REQUIRE_FALSE(content.find("information") == std::string::npos);
-            REQUIRE_FALSE(content.find("details") == std::string::npos);
+            REQUIRE(content.find("information") != std::string::npos);
+            REQUIRE(content.find("details") != std::string::npos);
             REQUIRE(content.find("debugging") == std::string::npos);
             REQUIRE(content.find("never ever") == std::string::npos);
         }

--- a/test/helpers/Testhelper.cpp
+++ b/test/helpers/Testhelper.cpp
@@ -1,5 +1,6 @@
 #include "Testhelper.h"
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 #include <vector>
 
@@ -24,38 +25,45 @@ irr::io::IFileSystem* Testhelper::getFileSystem() {
     return fileSystem_;
 }
 
-irr::core::stringc Testhelper::readFile(irr::io::path fileName) {
-    irr::io::IReadFile* file = fileSystem_->createAndOpenFile(fileName);
-    const intmax_t result = file->getSize();
-    if (result == -1L) {
-        std::cerr << "Error: Could not get file size of \"" << fileName.c_str() << "\"!" << std::endl;
+std::string Testhelper::readFile(const char* fileName) {
+    std::fstream filestream(fileName, std::fstream::in);
+    if (filestream.fail()) {
+        filestream.close();
+        std::cerr << "Error: Could not open file \"" << fileName << "\"!" << std::endl;
         exit(EXIT_FAILURE);
     }
-    const uint32_t size = static_cast<uint32_t>(result);
-    std::vector<uint8_t> buffer(size);
-    file->read(buffer.data(), size);
-    file->drop();
-    return buffer.data();
+    filestream.seekg (0, filestream.end);
+    std::streampos size = filestream.tellg();
+    filestream.seekg (0, filestream.beg);
+    if (size <= 0) {
+        filestream.close();
+        std::cerr << "Error: Could not get file size of \"" << fileName << "\"!" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+    std::vector<char> buffer(static_cast<uint32_t>(size) + 4);
+    filestream.read(&buffer[0], static_cast<std::streamsize>(size));
+    filestream.close();
+    return std::string(buffer.begin(), buffer.end());
 }
 
-void Testhelper::writeFile(irr::io::path fileName, const irr::core::stringc& content) {
+void Testhelper::writeFile(const char* fileName, const irr::core::stringc& content) {
     irr::io::IWriteFile* file = fileSystem_->createAndWriteFile(fileName, /* append = */ false);
     file->write(content.c_str(), content.size());
     file->drop();
 }
 
-uint32_t Testhelper::getFileSize(irr::io::path fileName) {
+uint32_t Testhelper::getFileSize(const char* fileName) {
     irr::io::IReadFile* file = fileSystem_->createAndOpenFile(fileName);
     const intmax_t result = file->getSize();
     if (result == -1L) {
-        std::cerr << "Error: Could not get file size of \"" << fileName.c_str() << "\"!" << std::endl;
+        std::cerr << "Error: Could not get file size of \"" << fileName << "\"!" << std::endl;
         exit(EXIT_FAILURE);
     }
     file->drop();
     return static_cast<uint32_t>(result);
 }
 
-bool Testhelper::existFile(irr::io::path fileName) {
+bool Testhelper::existFile(const char* fileName) {
     return fileSystem_->existFile(fileName);
 }
 

--- a/test/helpers/Testhelper.h
+++ b/test/helpers/Testhelper.h
@@ -3,6 +3,7 @@
 
 #include "irrlicht.h"
 #include <cstdint>
+#include <string>
 #include "../../source/Leviathan/core/Logger.h" // we dogfood our own code ;)
 
 class Testhelper {
@@ -13,10 +14,10 @@ public:
     void operator=(const Testhelper&) = delete;
     irr::IrrlichtDevice* getGraphicEngine();
     irr::io::IFileSystem* getFileSystem();
-    irr::core::stringc readFile(irr::io::path fileName);
-    void writeFile(irr::io::path fileName, const irr::core::stringc& content);
-    uint32_t getFileSize(irr::io::path fileName);
-    bool existFile(irr::io::path fileName);
+    std::string readFile(const char* fileName);
+    void writeFile(const char* fileName, const irr::core::stringc& content);
+    uint32_t getFileSize(const char* fileName);
+    bool existFile(const char* fileName);
     static leviathan::core::Logger& Logger();
 
 private:

--- a/test/input/ActionsTest.cpp
+++ b/test/input/ActionsTest.cpp
@@ -10,7 +10,7 @@ using namespace fakeit;
 
 TEST_CASE("Action Mapping", "[unit]") {
     Testhelper testhelper;
-    const irr::io::path mappingsFileName = "testactionmappings.yml";
+    const char* mappingsFileName = "testactionmappings.yml";
     irr::core::stringc content = "---\n"
                                  "- name: talk\n"
                                  "  id: 1\n"


### PR DESCRIPTION
This PR will
- remove Irrlicht types from Logger
- refactor all parts that use the Logger
- fix error in `main()`
- refactor TestHelper to use `const char *` instead of `irr:io::path`. As soon as MinGW fully supports `std::filesystem` we can use this instead.