### PR TITLE
Add texture loading to game engine

### DIFF
--- a/source/Leviathan/CMakeLists.txt
+++ b/source/Leviathan/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(leviathan SHARED
   input/MouseEventActions.cpp
   video/Camera.cpp
   video/MeshHelper.cpp
+  video/Textures.cpp
   world/Ground.cpp
   LeviathanDevice.cpp
 )

--- a/source/Leviathan/LeviathanDevice.cpp
+++ b/source/Leviathan/LeviathanDevice.cpp
@@ -12,9 +12,10 @@ namespace leviathan {
         initializeGraphicEngine();
         graphicEngine_->setEventReceiver(&eventReceiver_);
         textures_ = std::make_unique<video::Textures>(graphicEngine_->getVideoDriver(), logger_);
-        mousePointerControl_ = std::make_unique<gui::MousePointerControl>(eventReceiver_, graphicEngine_, logger_);
+        mousePointerControl_ = std::make_unique<gui::MousePointerControl>(
+            eventReceiver_, graphicEngine_, logger_, *textures_);
         menuControl_ = std::make_unique<gui::MenuControl>(
-            graphicEngine_->getGUIEnvironment(), graphicEngine_->getVideoDriver(), eventReceiver_);
+            graphicEngine_->getGUIEnvironment(), graphicEngine_->getVideoDriver(), eventReceiver_, *textures_);
         camera_ = std::make_unique<video::Camera>(graphicEngine_->getSceneManager(), configuration_);
         heroes_ = std::make_unique<characters::Heroes>(graphicEngine_->getSceneManager());
         ground_ = std::make_unique<world::Ground>(graphicEngine_->getSceneManager());

--- a/source/Leviathan/LeviathanDevice.cpp
+++ b/source/Leviathan/LeviathanDevice.cpp
@@ -11,6 +11,7 @@ namespace leviathan {
         randomizer_.start(static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count()));
         initializeGraphicEngine();
         graphicEngine_->setEventReceiver(&eventReceiver_);
+        textures_ = std::make_unique<video::Textures>(graphicEngine_->getVideoDriver(), logger_);
         mousePointerControl_ = std::make_unique<gui::MousePointerControl>(eventReceiver_, graphicEngine_, logger_);
         menuControl_ = std::make_unique<gui::MenuControl>(
             graphicEngine_->getGUIEnvironment(), graphicEngine_->getVideoDriver(), eventReceiver_);

--- a/source/Leviathan/LeviathanDevice.cpp
+++ b/source/Leviathan/LeviathanDevice.cpp
@@ -6,8 +6,8 @@
 
 namespace leviathan {
     LeviathanDevice::LeviathanDevice(const char* fileName)
-    : configuration_(fileName), logger_(LOG_FILE_NAME, configuration_.getLoggingLevel()), gameStateManager_(logger_),
-      actions_(eventReceiver_, logger_) {
+    : configuration_(fileName), logger_(LOG_FILE_NAME, configuration_.getLoggingLevel()), timeControl_(),
+      gameStateManager_(logger_), randomizer_(), eventReceiver_(), actions_(eventReceiver_, logger_) {
         randomizer_.start(static_cast<uint32_t>(std::chrono::system_clock::now().time_since_epoch().count()));
         initializeGraphicEngine();
         graphicEngine_->setEventReceiver(&eventReceiver_);

--- a/source/Leviathan/LeviathanDevice.h
+++ b/source/Leviathan/LeviathanDevice.h
@@ -19,6 +19,7 @@
 #include "input/EventReceiver.h"
 #include "irrlicht.h"
 #include "video/Camera.h"
+#include "video/Textures.h"
 #include "world/Ground.h"
 #include <memory>
 
@@ -121,6 +122,7 @@ namespace leviathan {
         core::Randomizer randomizer_ = core::Randomizer();
         input::EventReceiver eventReceiver_ = input::EventReceiver();
         input::Actions actions_;
+        std::unique_ptr<video::Textures> textures_ = nullptr;
         std::unique_ptr<gui::MenuControl> menuControl_ = nullptr;
         std::unique_ptr<gui::MousePointerControl> mousePointerControl_ = nullptr;
         std::unique_ptr<video::Camera> camera_ = nullptr;

--- a/source/Leviathan/LeviathanDevice.h
+++ b/source/Leviathan/LeviathanDevice.h
@@ -117,10 +117,10 @@ namespace leviathan {
         core::Configuration configuration_;
         core::Logger logger_;
         irr::IrrlichtDevice* graphicEngine_ = nullptr;
-        core::TimeControl timeControl_ = core::TimeControl();
+        core::TimeControl timeControl_;
         core::GameStateManager gameStateManager_;
-        core::Randomizer randomizer_ = core::Randomizer();
-        input::EventReceiver eventReceiver_ = input::EventReceiver();
+        core::Randomizer randomizer_;
+        input::EventReceiver eventReceiver_;
         input::Actions actions_;
         std::unique_ptr<video::Textures> textures_ = nullptr;
         std::unique_ptr<gui::MenuControl> menuControl_ = nullptr;

--- a/source/Leviathan/gui/MenuControl.cpp
+++ b/source/Leviathan/gui/MenuControl.cpp
@@ -1,12 +1,11 @@
 #include "MenuControl.h"
-#include "../video/Constants.h"
 #include <cstdint>
 
 namespace leviathan {
     namespace gui {
-        MenuControl::MenuControl(
-            irr::gui::IGUIEnvironment* guiEnv, irr::video::IVideoDriver* videoDriver, input::IEventProducer& producer)
-        : _guiEnv(guiEnv), _videoDriver(videoDriver), _producer(producer) {
+        MenuControl::MenuControl(irr::gui::IGUIEnvironment* guiEnv, irr::video::IVideoDriver* videoDriver,
+            input::IEventProducer& producer, leviathan::video::Textures& textures)
+        : _guiEnv(guiEnv), _videoDriver(videoDriver), _producer(producer), textures_(textures) {
             _producer.subscribe(*this, irr::EET_MOUSE_INPUT_EVENT);
             _producer.subscribe(*this, irr::EET_KEY_INPUT_EVENT);
             _producer.subscribe(*this, irr::EET_GUI_EVENT);
@@ -89,14 +88,11 @@ namespace leviathan {
         /* private */
 
         irr::video::ITexture* MenuControl::loadTexture(const std::string& filename, bool makeTransparent) {
-            // GenericHelperMethods& helper = GenericHelperMethods::getInstance();
-            // helper.validateFileExistence( "GFX/menues1.bmp" );
-            _videoDriver->setTextureCreationFlag(irr::video::ETCF_CREATE_MIP_MAPS, false);  // don't create LOD textures
-            irr::video::ITexture* texture = _videoDriver->getTexture(filename.c_str());
             if (makeTransparent) {
-                _videoDriver->makeColorKeyTexture(texture, video::COL_MAGICPINK);
+                return textures_.getWithColorKeyTransparency(filename.c_str());
             }
-            return texture;
+
+            return textures_.get(filename.c_str());
         }
     }
 }

--- a/source/Leviathan/gui/MenuControl.h
+++ b/source/Leviathan/gui/MenuControl.h
@@ -8,6 +8,7 @@
 
 #include "../input/IEventConsumer.h"
 #include "../input/IEventProducer.h"
+#include "../video/Textures.h"
 #include "Menu.h"
 #include "irrlicht.h"
 #include "types.h"
@@ -27,9 +28,10 @@ namespace leviathan {
              *  \param guiEnv: Zeiger auf die GUI-Umgebung der Graphic Engine
              *  \param videoDriver: Zeiger auf den Videotreiber der Graphic Engine
              *  \param producer: produziert (versendet) Events
+             *  \param textures: Instanz der Texturenverwaltung
              */
             MenuControl(irr::gui::IGUIEnvironment* guiEnv, irr::video::IVideoDriver* videoDriver,
-                input::IEventProducer& producer);
+                input::IEventProducer& producer, leviathan::video::Textures& textures);
 
             ~MenuControl();
 
@@ -75,6 +77,7 @@ namespace leviathan {
             irr::gui::IGUIEnvironment* _guiEnv = nullptr;
             irr::video::IVideoDriver* _videoDriver = nullptr;
             input::IEventProducer& _producer;
+            leviathan::video::Textures& textures_;
             std::map<std::wstring, std::unique_ptr<Menu>> _menus = std::map<std::wstring, std::unique_ptr<Menu>>();
 
             irr::video::ITexture* loadTexture(const std::string& filename, bool makeTransparent);

--- a/source/Leviathan/gui/MousePointerControl.cpp
+++ b/source/Leviathan/gui/MousePointerControl.cpp
@@ -1,17 +1,17 @@
 #include "MousePointerControl.h"
-#include "../video/Constants.h"
 #include <stdexcept>
 
 namespace leviathan {
     namespace gui {
         MousePointerControl::MousePointerControl(leviathan::input::IEventProducer& producer,
-            irr::IrrlichtDevice* graphicDevice, leviathan::core::Logger& logger)
-        : logger_(logger), graphicDevice_(graphicDevice) {
+            irr::IrrlichtDevice* graphicDevice, leviathan::core::Logger& logger, leviathan::video::Textures& textures)
+        : logger_(logger), textures_(textures), graphicDevice_(graphicDevice) {
             producer.subscribe(*this, irr::EET_MOUSE_INPUT_EVENT);
         }
 
         bool MousePointerControl::onEvent(const irr::SEvent& event) {
             if (event.MouseInput.Event != irr::EMIE_MOUSE_MOVED) return false;
+
             position_.X = event.MouseInput.X;
             position_.Y = event.MouseInput.Y;
             return true;
@@ -19,20 +19,16 @@ namespace leviathan {
 
         void MousePointerControl::createMousePointer(const uint32_t id, const irr::io::path& imageFileName,
             const irr::core::recti& imageArea, const irr::core::vector2di& hotSpot) {
-            irr::video::ITexture* texture = graphicDevice_->getVideoDriver()->getTexture(imageFileName);
-            if (texture == nullptr) {
-                logger_.text << "[Warning] - MousePointerControl - cannot load texture " << imageFileName.c_str()
-                             << "!";
-                logger_.write(leviathan::core::Logger::Level::DEBUG);
-                return;
-            }
             if (baseImage_[id] != nullptr) {
                 logger_.text << "[Warning] - MousePointerControl - id " << id << " already exists!";
                 logger_.write(leviathan::core::Logger::Level::DEBUG);
                 return;
             }
+
+            irr::video::ITexture* texture = textures_.getWithColorKeyTransparency(imageFileName.c_str());
+            if (texture == nullptr) return;
+
             baseImage_[id] = texture;
-            graphicDevice_->getVideoDriver()->makeColorKeyTexture(baseImage_[id], video::COL_MAGICPINK);
             imageArea_[id] = imageArea;
             hotSpot_[id] = hotSpot;
         }
@@ -52,6 +48,7 @@ namespace leviathan {
 
         void MousePointerControl::draw() {
             if (activeMousePointer_ == 0) return;
+
             graphicDevice_->getVideoDriver()->draw2DImage(baseImage_.at(activeMousePointer_),
                 position_ - hotSpot_.at(activeMousePointer_),  // upper left corner of mouse pointer image
                 imageArea_.at(activeMousePointer_),

--- a/source/Leviathan/gui/MousePointerControl.h
+++ b/source/Leviathan/gui/MousePointerControl.h
@@ -8,6 +8,7 @@
 #include "../core/Logger.h"
 #include "../input/IEventConsumer.h"
 #include "../input/IEventProducer.h"
+#include "../video/Textures.h"
 #include "irrlicht.h"
 #include <cstdint>
 #include <unordered_map>
@@ -24,9 +25,10 @@ namespace leviathan {
              *  \param producer: produziert (versendet) Events
              *  \param graphicDevice: initialisiertes Irrlicht Device
              *  \param logger: Instanz eines Loggers
+             *  \param textures: Instanz der Texturenverwaltung
              */
             MousePointerControl(leviathan::input::IEventProducer& producer, irr::IrrlichtDevice* graphicDevice,
-                leviathan::core::Logger& logger);
+                leviathan::core::Logger& logger, leviathan::video::Textures& textures);
 
             ~MousePointerControl() = default;
             MousePointerControl() = delete;
@@ -59,6 +61,7 @@ namespace leviathan {
 
         private:
             leviathan::core::Logger& logger_;
+            leviathan::video::Textures& textures_;
             uint32_t activeMousePointer_ = 0;
             const irr::video::SColor backgroundColor_ = irr::video::SColor(255, 255, 255, 255);
             irr::core::vector2di position_ = irr::core::vector2di(0, 0);

--- a/source/Leviathan/video/Textures.cpp
+++ b/source/Leviathan/video/Textures.cpp
@@ -1,0 +1,19 @@
+#include "Textures.h"
+
+namespace leviathan {
+    namespace video {
+        Textures::Textures(irr::video::IVideoDriver* videoDriver, leviathan::core::Logger& logger)
+        : videoDriver_(videoDriver), logger_(logger) {}
+
+        irr::video::ITexture* Textures::get(const char* fileName) {
+            videoDriver_->setTextureCreationFlag(irr::video::ETCF_CREATE_MIP_MAPS, false);  // don't create LOD textures
+            irr::video::ITexture* texture = videoDriver_->getTexture(fileName);
+            if (texture == nullptr) {
+                logger_.text << "[Warning] - cannot load texture " << fileName << "!";
+                logger_.write(core::Logger::Level::DEBUG);
+                return nullptr;
+            }
+            return texture;
+        }
+    }
+}

--- a/source/Leviathan/video/Textures.cpp
+++ b/source/Leviathan/video/Textures.cpp
@@ -1,4 +1,5 @@
 #include "Textures.h"
+#include "Constants.h"
 
 namespace leviathan {
     namespace video {
@@ -6,12 +7,24 @@ namespace leviathan {
         : videoDriver_(videoDriver), logger_(logger) {}
 
         irr::video::ITexture* Textures::get(const char* fileName) {
+            if (textures_.find(fileName) != textures_.end()) return textures_[fileName].irrTexture;
+
             videoDriver_->setTextureCreationFlag(irr::video::ETCF_CREATE_MIP_MAPS, false);  // don't create LOD textures
-            irr::video::ITexture* texture = videoDriver_->getTexture(fileName);
-            if (texture == nullptr) {
+            Texture tex;
+            tex.irrTexture = videoDriver_->getTexture(fileName);
+            if (tex.irrTexture == nullptr) {
                 logger_.text << "[Warning] - cannot load texture " << fileName << "!";
                 logger_.write(core::Logger::Level::DEBUG);
-                return nullptr;
+            }
+            textures_[fileName] = tex;
+            return tex.irrTexture;
+        }
+
+        irr::video::ITexture* Textures::getWithColorKeyTransparency(const char* fileName) {
+            irr::video::ITexture* texture = get(fileName);
+            if (!textures_[fileName].alreadyColorKeyed) {
+                videoDriver_->makeColorKeyTexture(texture, video::COL_MAGICPINK);
+                textures_[fileName].alreadyColorKeyed = true;
             }
             return texture;
         }

--- a/source/Leviathan/video/Textures.h
+++ b/source/Leviathan/video/Textures.h
@@ -14,11 +14,6 @@
 
 namespace leviathan {
     namespace video {
-        struct Texture {
-            bool alreadyColorKeyed = false;
-            irr::video::ITexture* irrTexture = nullptr;
-        };
-
         /*  \class Textures
          *  \brief Einfaches laden von Texturen
          */
@@ -48,6 +43,11 @@ namespace leviathan {
             irr::video::ITexture* getWithColorKeyTransparency(const char* fileName);
 
         private:
+            struct Texture {
+                bool alreadyColorKeyed = false;
+                irr::video::ITexture* irrTexture = nullptr;
+            };
+
             irr::video::IVideoDriver* videoDriver_ = nullptr;
             leviathan::core::Logger& logger_;
             std::unordered_map<std::string, Texture> textures_ = std::unordered_map<std::string, Texture>();

--- a/source/Leviathan/video/Textures.h
+++ b/source/Leviathan/video/Textures.h
@@ -9,9 +9,15 @@
 #include "../core/Logger.h"
 #include "ITexture.h"
 #include "IVideoDriver.h"
+#include <string>
+#include <unordered_map>
 
 namespace leviathan {
     namespace video {
+        struct Texture {
+            bool alreadyColorKeyed = false;
+            irr::video::ITexture* irrTexture = nullptr;
+        };
 
         /*  \class Textures
          *  \brief Einfaches laden von Texturen
@@ -35,9 +41,16 @@ namespace leviathan {
              */
             irr::video::ITexture* get(const char* fileName);
 
+            /*  \brief Lädt eine Textur und wandelt Magic Pink in Transparenz um, ansonsten ohne weitere Features.
+             *  \note Ist die Textur bereits geladen, wird sie nicht noch einmal geladen.
+             *  \param fileName: Name und Pfad der Textur-Datei
+             */
+            irr::video::ITexture* getWithColorKeyTransparency(const char* fileName);
+
         private:
             irr::video::IVideoDriver* videoDriver_ = nullptr;
             leviathan::core::Logger& logger_;
+            std::unordered_map<std::string, Texture> textures_ = std::unordered_map<std::string, Texture>();
         };
     }
 }

--- a/source/Leviathan/video/Textures.h
+++ b/source/Leviathan/video/Textures.h
@@ -1,0 +1,45 @@
+/*  \file Textures.h
+ *  \brief Einfaches laden von Texturen.
+ *  \note Bestandteil der Leviathan Engine
+ */
+
+#ifndef LEVIATHAN_VIDEO_TEXTURES_H
+#define LEVIATHAN_VIDEO_TEXTURES_H
+
+#include "../core/Logger.h"
+#include "ITexture.h"
+#include "IVideoDriver.h"
+
+namespace leviathan {
+    namespace video {
+
+        /*  \class Textures
+         *  \brief Einfaches laden von Texturen
+         */
+        class Textures {
+        public:
+            /*  \brief Konstruktor.
+             *  \param videoDriver: Zeiger auf den Videotreiber der Graphic Engine
+             *  \param logger: Instanz eines Loggers
+             */
+            Textures(irr::video::IVideoDriver* videoDriver, leviathan::core::Logger& logger);
+
+            ~Textures() = default;
+            Textures() = delete;
+            Textures(const Textures&) = delete;
+            Textures& operator=(const Textures&) = delete;
+
+            /*  \brief Lädt eine Textur, ohne weitere Features.
+             *  \note Ist die Textur bereits geladen, wird sie nicht noch einmal geladen.
+             *  \param fileName: Name und Pfad der Textur-Datei
+             */
+            irr::video::ITexture* get(const char* fileName);
+
+        private:
+            irr::video::IVideoDriver* videoDriver_ = nullptr;
+            leviathan::core::Logger& logger_;
+        };
+    }
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(unit_tests
   input/KeyboardEventActionsTest.cpp
   input/MouseEventActionsTest.cpp
   video/CameraTest.cpp
+  video/TexturesTest.cpp
   world/GroundTest.cpp
   LeviathanDeviceTest.cpp
   unit_tests.cpp

--- a/test/gui/MenuControlTest.cpp
+++ b/test/gui/MenuControlTest.cpp
@@ -2,6 +2,7 @@
 #include "../../source/Leviathan/input/IEventProducer.h"
 #include "../helpers/IGUIImageMock.hpp"
 #include "../helpers/IImageMock.hpp"
+#include "../helpers/TestHelper.h"
 #include "catch.hpp"
 #include "fakeit.hpp"
 #include "irrlicht.h"
@@ -25,12 +26,13 @@ TEST_CASE("MenuControl", "[unit]") {
     Mock<irr::gui::IGUIEnvironment> guiEnvironmentMock;
     Fake(Method(guiEnvironmentMock, addEmptySpriteBank), Method(guiEnvironmentMock, getRootGUIElement));
     Mock<irr::video::IVideoDriver> videoDriverMock;
+    leviathan::video::Textures textures(&videoDriverMock.get(), TestHelper::Logger());
     Mock<leviathan::input::IEventProducer> eventBrokerMock;
     Fake(Method(eventBrokerMock, subscribe), Method(eventBrokerMock, unsubscribe));
 
     SECTION("subscribes and unsubscribes to an action producer for certain input event types") {
         auto subject = new leviathan::gui::MenuControl(
-            &guiEnvironmentMock.get(), &videoDriverMock.get(), eventBrokerMock.get());
+            &guiEnvironmentMock.get(), &videoDriverMock.get(), eventBrokerMock.get(), textures);
         // FIXME issue with the mock when .Using(subject, ...) instead of .Using(_, ...)
         Verify(Method(eventBrokerMock, subscribe).Using(_, irr::EET_GUI_EVENT)).Exactly(Once);
         Verify(Method(eventBrokerMock, subscribe).Using(_, irr::EET_MOUSE_INPUT_EVENT)).Exactly(Once);
@@ -60,7 +62,8 @@ TEST_CASE("MenuControl", "[unit]") {
         When(OverloadedMethod(videoDriverMock, createImage, createImageArgs)).AlwaysReturn(image);
         When(Method(guiEnvironmentMock, addModalScreen)).Return(&menu);
 
-        leviathan::gui::MenuControl subject(&guiEnvironmentMock.get(), &videoDriverMock.get(), eventBrokerMock.get());
+        leviathan::gui::MenuControl subject(
+            &guiEnvironmentMock.get(), &videoDriverMock.get(), eventBrokerMock.get(), textures);
 
         SECTION("#addMenu adds a modal screen as menu root") {
             irr::gui::IGUIElement anotherMenu(

--- a/test/gui/MousePointerControlTest.cpp
+++ b/test/gui/MousePointerControlTest.cpp
@@ -22,6 +22,7 @@ TEST_CASE("MousePointerControl", "[integration]") {
     Mock<irr::video::ITexture> textureMock;
     Mock<irr::video::IVideoDriver> videoDriverSpy(*(TestHelper::graphicEngine()->getVideoDriver()));
     When(OverloadedMethod(videoDriverSpy, getTexture, getTextureArgs)).AlwaysReturn(&textureMock.get());
+    leviathan::video::Textures textures(TestHelper::graphicEngine()->getVideoDriver(), TestHelper::Logger());
     // FakeIt has a bug (https://github.com/eranpeer/FakeIt/issues/92) where reference arguments are tested way too
     // late, so we have to remember them at call time:
     irr::core::vector2di lastRememberedPosition;
@@ -50,7 +51,7 @@ TEST_CASE("MousePointerControl", "[integration]") {
     keyboardEvent.KeyInput.Key = irr::KEY_RETURN;
     keyboardEvent.KeyInput.PressedDown = true;
     leviathan::gui::MousePointerControl subject(
-        eventBrokerMock.get(), TestHelper::graphicEngine(), TestHelper::Logger());
+        eventBrokerMock.get(), TestHelper::graphicEngine(), TestHelper::Logger(), textures);
 
     SECTION("events") {
         SECTION("subscribes to an event producer for movement input events") {

--- a/test/helpers/Testhelper.cpp
+++ b/test/helpers/Testhelper.cpp
@@ -1,5 +1,6 @@
 #include "TestHelper.h"
 #include <cstdlib>
+#include <stdio.h>
 #include <vector>
 
 TestHelper& TestHelper::instance() {
@@ -77,6 +78,10 @@ void TestHelper::writeFile(const char* fileName, const std::string& content) {
 bool TestHelper::existFile(const char* fileName) {
     std::ifstream infile(fileName);
     return infile.good();
+}
+
+void TestHelper::deleteFile(const char* fileName) {
+    remove(fileName);
 }
 
 TestHelper::TestHelper() {

--- a/test/helpers/Testhelper.h
+++ b/test/helpers/Testhelper.h
@@ -48,6 +48,10 @@ public:
      */
     static void writeFile(const char* fileName, const std::string& content);
 
+    /*! \brief Delete a file.
+     */
+    static void deleteFile(const char* fileName);
+
 private:
     irr::IrrlichtDevice* mGraphicEngine = nullptr;
     uint32_t mUniqueId = 0;

--- a/test/video/TexturesTest.cpp
+++ b/test/video/TexturesTest.cpp
@@ -1,0 +1,39 @@
+#include "../../source/Leviathan/video/Textures.h"
+#include "../helpers/TestHelper.h"
+#include "IImage.h"
+#include "ITexture.h"
+#include "IVideoDriver.h"
+#include "catch.hpp"
+#include "fakeit.hpp"
+
+using namespace fakeit;
+
+#define getTextureArgs irr::video::ITexture*(const irr::io::path&)
+
+TEST_CASE("Textures", "[integration]") {
+    irr::video::IVideoDriver* videoDriver = TestHelper::graphicEngine()->getVideoDriver();
+    const char* textureFileName = "sampleTexture.jpg";
+    irr::video::IImage* sampleImage = videoDriver->createImage(irr::video::ECF_A1R5G5B5, {1, 1});
+    leviathan::video::Textures subject(videoDriver, TestHelper::Logger());
+
+    SECTION("can be retrieved by file name") {
+        videoDriver->writeImageToFile(sampleImage, textureFileName);  // create a test image file
+        irr::video::ITexture* sampleTexture = subject.get(textureFileName);
+        REQUIRE(sampleTexture != nullptr);
+
+        SECTION("with only basic features") {
+            REQUIRE_FALSE(videoDriver->getTextureCreationFlag(irr::video::ETCF_CREATE_MIP_MAPS));
+        }
+
+        SECTION("are loaded only once") {
+            TestHelper::deleteFile(textureFileName);  // delete the image file, now only the image in memory remains
+            REQUIRE(subject.get(textureFileName) == sampleTexture);
+        }
+    }
+
+    SECTION("can have color-keyed transparency") {
+        SECTION("which will be done only once") {}
+    }
+
+    SECTION("can be removed from memory") {}
+}


### PR DESCRIPTION
This PR adds the ability to load textures by decoupling it a bit from the graphic engine.

Belongs to https://github.com/dixx/Die_Chroniken_eines_namenlosen_Spiels/issues/148.